### PR TITLE
Use PAN data(train, test) and measure the performance

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
         "max_seq_len": 100,
         "max_post_len": 300,
         "batch_size": 16,
-        "epochs": 12,
+        "epochs": 30,
         "lstm_dropout": 0.1,
         "fc_dropout": 0.3,
         "beta": {

--- a/get_data_id.py
+++ b/get_data_id.py
@@ -74,23 +74,23 @@ random.shuffle(eid_list)
 
 # fold 나누기 -> 총 5개의 fold로 나누기
 len_eid_list = len(eid_list)
-fold_unit = int(len_eid_list / 6)
+fold_unit = int(len_eid_list / 10)
 
 val_eid_list = eid_list[:fold_unit]
 
-fold_0 = eid_list[fold_unit:fold_unit * 2]
-fold_1 = eid_list[fold_unit * 2:fold_unit * 3]
-fold_2 = eid_list[fold_unit * 3:fold_unit * 4]
-fold_3 = eid_list[fold_unit * 4:fold_unit * 5]
-fold_4 = eid_list[fold_unit * 5:]
+fold_0 = eid_list[fold_unit:]
+# fold_1 = eid_list[fold_unit * 2:fold_unit * 3]
+# fold_2 = eid_list[fold_unit * 3:fold_unit * 4]
+# fold_3 = eid_list[fold_unit * 4:fold_unit * 5]
+# fold_4 = eid_list[fold_unit * 5:]
 
 fold_0_test, fold_0_train = get_test_train(fold_0)
-fold_1_test, fold_1_train = get_test_train(fold_1)
-fold_2_test, fold_2_train = get_test_train(fold_2)
-fold_3_test, fold_3_train = get_test_train(fold_3)
-fold_4_test, fold_4_train = get_test_train(fold_4)
+# fold_1_test, fold_1_train = get_test_train(fold_1)
+# fold_2_test, fold_2_train = get_test_train(fold_2)
+# fold_3_test, fold_3_train = get_test_train(fold_3)
+# fold_4_test, fold_4_train = get_test_train(fold_4)
 
-data_ids = {"val": val_eid_list, "fold0": {'test': fold_0_test, 'train': fold_0_train}, "fold1": {'test': fold_1_test, 'train': fold_1_train}, "fold2": {
-    'test': fold_2_test, 'train': fold_2_train}, "fold3": {'test': fold_3_test, 'train': fold_3_train}, "fold4": {'test': fold_4_test, 'train': fold_4_train}, }
+data_ids = {"val": val_eid_list, "fold0": {
+    'test': fold_0_test, 'train': fold_0_train}, }
 
 save_pickle(data=data_ids, path=PHEME_path, filename='PAN_data_ids')

--- a/get_data_id.py
+++ b/get_data_id.py
@@ -2,6 +2,7 @@ import pickle
 import os
 import numpy as np
 import random
+import copy
 
 
 def load_pickle(path, filename):
@@ -15,30 +16,6 @@ def save_pickle(data, path, filename):
         pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
 
 
-def shuffle_lists(featllist, labellist, total_epoch, epoch, thirdparty=None):
-    # seed = 100
-    np.random.seed(1)
-    seed_set = np.random.randint(100, size=total_epoch)
-    seed_set = seed_set.tolist()
-
-    if labellist is None:
-        np.random.seed(seed_set[epoch])
-        random.shuffle(featllist)
-        return featllist
-    elif labellist is not None and thirdparty is None:
-        combined = list(zip(featllist, labellist))
-        np.random.seed(seed_set[epoch])
-        random.shuffle(combined)
-        featllist, labellist = zip(*combined)
-        return featllist, labellist
-    else:
-        combined = list(zip(featllist, labellist, thirdparty))
-        np.random.seed(seed_set[epoch])
-        random.shuffle(combined)
-        featllist, labellist, thirdparty = zip(*combined)
-        return featllist, labellist, thirdparty
-
-
 def get_test_train(fold):
     len_fold = len(fold)
     fold_unit = int(len_fold / 5)
@@ -47,17 +24,6 @@ def get_test_train(fold):
     train_list = fold[fold_unit:]
 
     return test_list, train_list
-
-    # if len(fold) != 928:
-    #     test_list = fold[:234]
-    #     train_list = fold[234:]
-
-    #     return test_list, train_list
-
-    # test_list = fold[:232]
-    # train_list = fold[232:]
-
-    # return test_list, train_list
 
 
 PATH = '/home/jinmyeong/code/HEARD'
@@ -70,27 +36,51 @@ PHEME_data = load_pickle(path=PHEME_path, filename=filename)
 
 eid_list = list(PHEME_data.keys())
 
-random.shuffle(eid_list)
+# train_eid 만 뽑기
+train_eid_list = eid_list[:2820]
 
-# fold 나누기 -> 총 5개의 fold로 나누기
-len_eid_list = len(eid_list)
-fold_unit = int(len_eid_list / 10)
+# test_eid 만 뽑기
+test_eid_list = eid_list[2820:]
 
-val_eid_list = eid_list[:fold_unit]
+# # 겹치는 dev_eid 뽑기
+# copied_train_eid_list = copy.deepcopy(train_eid_list)
+# random.shuffle(copied_train_eid_list)
 
-fold_0 = eid_list[fold_unit:]
-# fold_1 = eid_list[fold_unit * 2:fold_unit * 3]
-# fold_2 = eid_list[fold_unit * 3:fold_unit * 4]
-# fold_3 = eid_list[fold_unit * 4:fold_unit * 5]
-# fold_4 = eid_list[fold_unit * 5:]
+# len_copied_train_eid_list = len(copied_train_eid_list)
+# fold_unit = int(len_copied_train_eid_list / 9)
+# val_eid_list = copied_train_eid_list[:fold_unit]
 
-fold_0_test, fold_0_train = get_test_train(fold_0)
-# fold_1_test, fold_1_train = get_test_train(fold_1)
-# fold_2_test, fold_2_train = get_test_train(fold_2)
-# fold_3_test, fold_3_train = get_test_train(fold_3)
-# fold_4_test, fold_4_train = get_test_train(fold_4)
+# 안 겹치는 dev_eid 뽑기
+len_train_eid_list = len(train_eid_list)
+random.shuffle(train_eid_list)
 
+fold_unit = int(len_train_eid_list / 6)
+val_eid_list = train_eid_list[:fold_unit]
+
+# # fold 나누기 -> 총 5개의 fold로 나누기
+# len_eid_list = len(eid_list)
+# fold_unit = int(len_eid_list / 10)
+
+# val_eid_list = eid_list[:fold_unit]
+
+# fold_0 = eid_list[fold_unit:]
+# # fold_1 = eid_list[fold_unit * 2:fold_unit * 3]
+# # fold_2 = eid_list[fold_unit * 3:fold_unit * 4]
+# # fold_3 = eid_list[fold_unit * 4:fold_unit * 5]
+# # fold_4 = eid_list[fold_unit * 5:]
+
+# fold_0_test, fold_0_train = get_test_train(fold_0)
+# # fold_1_test, fold_1_train = get_test_train(fold_1)
+# # fold_2_test, fold_2_train = get_test_train(fold_2)
+# # fold_3_test, fold_3_train = get_test_train(fold_3)
+# # fold_4_test, fold_4_train = get_test_train(fold_4)
+
+# 겹치는 dev
+# data_ids = {"val": val_eid_list, "fold0": {
+#     'test': test_eid_list, 'train': train_eid_list}, }
+
+# 원래 HEARD 세팅 값
 data_ids = {"val": val_eid_list, "fold0": {
-    'test': fold_0_test, 'train': fold_0_train}, }
+    'test': test_eid_list, 'train': train_eid_list[fold_unit:]}, }
 
 save_pickle(data=data_ids, path=PHEME_path, filename='PAN_data_ids')


### PR DESCRIPTION
# PAN test 데이터 활용법

### 🧶 Problem

PHEME 데이터가 test 데이터 셋을 따로 가지고 있지 않습니다.

이미 있는 base 데이터를 split해서 test 셋을 제작합니다.

따라서 우선 해야할 작업은 다음과 같습니다.

- PAN train 데이터 test 와 합치기
    - 어떤 idx 까지 train인지 test인지 알 필요있음
        - 애초에 raw data를 만들 때 부터 합쳐야겠다.
- data_id 수정
    - dev (train과 1:9)
    - test

### 🧶 PAN train + test 방법

json를 load 하고 각각의 list를 concat 합니다.

이 때, 주의할 점은 각각의 list의 길이를 알아야 한다는 점입니다.

- PAN_train
    - 길이: 2820
- PAN_test
    - 길이: 5643

**코드를 작성완료했습니다.**

### 🧶 data_id 수정

우선 PAN_to_PHEME 를 제작했습니다.

해야할 작업은 크게 3가지 입니다.

- [x]  val_eid_list 제작
- [x]  train_eid_list 제작
- [x]  test_eid_list 제작

### 성능

```python
Test_Acc 0.9729 | ER : 0.5608 | Test_R 0.9713 | Test_P 0.9680 | Test_F 0.9696 | SEA 0.8025
[+] Avg Results: Acc 0.9729| R 0.9713 | P 0.9680 | F 0.9696 | ER 0.5608 | SEA 0.8025
```